### PR TITLE
Remove stack trace from error message

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"reflect"
 	"runtime"
-	"runtime/debug"
 	"strconv"
 	"strings"
 )
@@ -94,8 +93,7 @@ func recovery(err *error) {
 			tmpError = errors.New("Unknown panic: " + reflect.TypeOf(r).String())
 		}
 
-		stackTrace := debug.Stack()
-		*err = fmt.Errorf("%s\n%s", tmpError.Error(), string(stackTrace))
+		*err = fmt.Errorf("%s\n%s", tmpError.Error())
 	}
 }
 

--- a/decode_test.go
+++ b/decode_test.go
@@ -855,4 +855,21 @@ b:
 			Ω(n.String()).Should(Equal("123"))
 		})
 	})
+	Context("When there are special characters", func() {
+		It("returns an error", func() {
+			d := NewDecoder(strings.NewReader(`
+---
+applications:
+ - name: m
+   services:
+       - !@#
+`))
+			var v interface{}
+
+			err := d.Decode(&v)
+			Ω(err).Should(HaveOccurred())
+			Ω(err.Error()).ShouldNot(ContainSubstring("decode.go"))
+
+		})
+	})
 })


### PR DESCRIPTION
If there are any parsing errors in yaml file then a debug stack trace is included as part of the error message. This error is then displayed to the user. In order to avoid displaying internal stack traces to the user I have removed the debug.Stack call to get the stack trace. Also added a test case that validates that there is no stack trace in the error message.

This is done for the story in CF foundation tracker:
[#88539284]
