### PR TITLE
Add defer close to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ func main() {
     println("File does not exist:", err.Error())
     os.Exit(1)
   }
-  
+  defer file.Close()
+
   document := new(interface{})
   decoder := candiedyaml.NewDecoder(file)
   err = decoder.Decode(document)
@@ -41,7 +42,8 @@ func main() {
     println("Failed to open file for writing:", err.Error())
     os.Exit(1)
   }
-  
+  defer fileToWrite.Close()
+
   encoder := candiedyaml.NewEncoder(fileToWrite)
   err = encoder.Encode(document)
 


### PR DESCRIPTION
Adhering to [Go best practice](http://blog.golang.org/defer-panic-and-recover) around file closing, we've added Close deferrals after the file methods in the README.

WIth: @BooleanCat