### PR TITLE
Add option in Encode to ignore omitempty tags

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -57,6 +57,8 @@ type Encoder struct {
 	event   yaml_event_t
 	flow    bool
 	err     error
+
+	IgnoreOmitEmpty bool
 }
 
 func Marshal(v interface{}) ([]byte, error) {
@@ -174,7 +176,7 @@ func (e *Encoder) emitStruct(tag string, v reflect.Value) {
 	e.mapping(tag, func() {
 		for _, f := range fields {
 			fv := fieldByIndex(v, f.index)
-			if !fv.IsValid() || f.omitEmpty && isEmptyValue(fv) {
+			if !fv.IsValid() || f.omitEmpty && isEmptyValue(fv) && !e.IgnoreOmitEmpty {
 				continue
 			}
 


### PR DESCRIPTION
Currently there isn't any way to marshal a struct and include empty fields that are tagged with `omitempty`. Creating a second struct with the same fields but without `omitempty` tags accomplishes the same thing, but this is a tedious process.

There might be a better way to expose this functionality, but I figured I'd put in a PR for one possible option.