### PR TITLE
Add quotes around strings containing a colon followed by whitespace

### DIFF
--- a/emitter.go
+++ b/emitter.go
@@ -1276,7 +1276,7 @@ func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
 
 	for i, w := 0, 0; i < len(value); i += w {
 		w = width(value[i])
-		followed_by_whitespace = i+w >= len(value) || is_blankz_at(value, w)
+		followed_by_whitespace = i+w >= len(value) || is_blankz_at(value, i+w)
 
 		if i == 0 {
 			switch value[i] {

--- a/encode_test.go
+++ b/encode_test.go
@@ -68,6 +68,14 @@ var _ = Describe("Encode", func() {
 
 		})
 
+		It("handles strings that contain colons followed by whitespace", func() {
+			err := enc.Encode("contains: colon")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(buf.String()).To(Equal(`'contains: colon'
+`))
+
+		})
+
 		Context("handles ints", func() {
 			It("handles ints", func() {
 				err := enc.Encode(13)


### PR DESCRIPTION
When marshaling, strings should be given quotes when they contain a colon followed by whitespace. This is needed to generate proper YAML.

For example, this program will output `B: contains: colon`, but it should output `B: 'contains: colon'`. This PR fixes the underlying issue that causes this.

```
package main

import (
	"fmt"
	yaml "github.com/cloudfoundry-incubator/candiedyaml"
)

type A struct {
	B string
}

func main() {
	a := A{"contains: colon"}
	data, err := yaml.Marshal(a)
	if err != nil {
		panic(err)
	}
	fmt.Println(string(data))
}
```