### PR TITLE
Allow strings to start with a colon

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -62,6 +62,15 @@ var _ = Describe("Decode", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(v).To(Equal(map[interface{}]interface{}{"": ""}))
 		})
+
+		It("Decodes strings starting with a colon", func() {
+			d := NewDecoder(strings.NewReader(`:colon
+`))
+			var v interface{}
+			err := d.Decode(&v)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(v).To(Equal(":colon"))
+		})
 	})
 
 	Context("Sequence", func() {

--- a/scanner.go
+++ b/scanner.go
@@ -909,7 +909,7 @@ func yaml_parser_fetch_next_token(parser *yaml_parser_t) bool {
 		b == '@' || b == '`') ||
 		(b == '-' && !is_blank(buf[pos+1])) ||
 		(parser.flow_level == 0 &&
-			(buf[pos] == '?' || buf[pos+1] == ':') &&
+			(buf[pos] == '?' || buf[pos] == ':') &&
 			!is_blank(buf[pos+1])) {
 		return yaml_parser_fetch_plain_scalar(parser)
 	}


### PR DESCRIPTION
Strings that begin with a colon are valid YAML, but candiedyaml currently gives an error for these. This PR fixes an underlying issue that was causing these errors to occur.